### PR TITLE
fix: fixes vrpn library cmake error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ class CMakeBuild(build_ext):
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" # to make sure vrpn compiles
         ]
         build_args = []
 


### PR DESCRIPTION
Running `pip install motioncapture` on `Ubuntu 22.04 and Ubuntu 24.04 x86_64` gave this error
```
Collecting motioncapture
  Using cached motioncapture-1.0a2.tar.gz (5.1 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: motioncapture
  Building wheel for motioncapture (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for motioncapture (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [132 lines of output]
      running bdist_wheel
      running build
      running build_ext
      CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.10 will be removed from a future version of
        CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
      
      -- The C compiler identification is GNU 13.3.0
      -- The CXX compiler identification is GNU 13.3.0
      -- Detecting C compiler ABI info
      -- Detecting C compiler ABI info - done
      -- Check for working C compiler: /usr/bin/cc - skipped
      -- Detecting C compile features
      -- Detecting C compile features - done
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /usr/bin/c++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      CMake Warning (dev) at CMakeLists.txt:21 (find_package):
        Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
        --help-policy CMP0167" for policy details.  Use the cmake_policy command to
        set the policy and suppress this warning.
      
      This warning is for project developers.  Use -Wno-dev to suppress it.
      
      -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found suitable version "1.83.0", minimum required is "1.5") found components: system
      CMake Deprecation Warning at deps/vicon-datastream-sdk/CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.10 will be removed from a future version of
        CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
      
      CMake Warning (dev) at deps/vicon-datastream-sdk/CMakeLists.txt:6 (find_package):
        Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
        --help-policy CMP0167" for policy details.  Use the cmake_policy command to
        set the policy and suppress this warning.
      
      This warning is for project developers.  Use -Wno-dev to suppress it.
      
      -- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found suitable version "1.83.0", minimum required is "1.5") found components: system thread
      -- Found Threads: TRUE
      CMake Deprecation Warning at deps/qualisys_cpp_sdk/CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.10 will be removed from a future version of
        CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
      
      CMake Error at deps/vrpn/CMakeLists.txt:1 (cmake_minimum_required):
        Compatibility with CMake < 3.5 has been removed from CMake.
      
        Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
        to tell CMake that the project requires at least <min> but has been updated
        to work with policies introduced by <max> or earlier.
      
        Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
      
      
      -- Configuring incomplete, errors occurred!
      Traceback (most recent call last):
        File "/home/xeon/Desktop/learning-ebpf/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/home/xeon/Desktop/learning-ebpf/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/xeon/Desktop/learning-ebpf/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
          return _build_backend().build_wheel(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 438, in build_wheel
          return _build(['bdist_wheel', '--dist-info-dir', str(metadata_directory)])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 426, in _build
          return self._build_with_temp_dir(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 407, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 104, in <module>
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 1104, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/command/bdist_wheel.py", line 370, in run
          self.run_command("build")
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 1104, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/build.py", line 135, in run
          self.run_command(cmd_name)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 1104, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/command/build_ext.py", line 99, in run
          _build_ext.run(self)
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/build_ext.py", line 368, in run
          self.build_extensions()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/build_ext.py", line 484, in build_extensions
          self._build_extensions_serial()
        File "/tmp/pip-build-env-6w99jo_d/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/build_ext.py", line 510, in _build_extensions_serial
          self.build_extension(ext)
        File "<string>", line 91, in build_extension
        File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['cmake', '/tmp/pip-install-8bj6ksa_/motioncapture_4cd6a2dd13984520a753417fb02d91b6', '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=/tmp/pip-install-8bj6ksa_/motioncapture_4cd6a2dd13984520a753417fb02d91b6/build/lib.linux-x86_64-cpython-312/', '-DPYTHON_EXECUTABLE=/home/xeon/Desktop/learning-ebpf/.venv/bin/python', '-DCMAKE_BUILD_TYPE=Release', '-GNinja']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for motioncapture
Failed to build motioncapture
ERROR: Failed to build installable wheels for some pyproject.toml based projects (motioncapture)
```
My computers have `cmake 4.0.0` installed as evidenced by:
```bash
$ cmake --version
cmake version 4.0.0
```
This was traced to the `vrpn` librarynot getting compiled and this PR is a temporary fix so that the package installs properly.